### PR TITLE
Fix optimization-study correctness bugs 

### DIFF
--- a/redis_retrieval_optimizer/bayes_study.py
+++ b/redis_retrieval_optimizer/bayes_study.py
@@ -21,57 +21,72 @@ from redis_retrieval_optimizer.search_methods import SEARCH_METHOD_MAP
 
 warnings.filterwarnings("ignore")
 
-METRICS: dict = {
-    "search_method": [],
-    "total_indexing_time": [],
-    "avg_query_time": [],
-    "model": [],
-    "model_dim": [],
-    "ret_k": [],
-    "recall": [],
-    "ndcg": [],
-    "f1": [],
-    "precision": [],
-    "algorithm": [],
-    "ef_construction": [],
-    "ef_runtime": [],
-    "m": [],
-    "distance_metric": [],
-    "vector_data_type": [],
-    "objective_value": [],
-    "total_memory_mb": [],
-}
+
+def new_metrics() -> dict:
+    """Fresh, empty metrics accumulator for a single study run.
+
+    Kept as a per-run local (threaded through ``objective``) rather than a
+    module global so repeated ``run_bayes_study`` calls don't accumulate rows
+    from prior runs.
+    """
+    return {
+        "search_method": [],
+        "total_indexing_time": [],
+        "avg_query_time": [],
+        "model": [],
+        "model_dim": [],
+        "ret_k": [],
+        "recall": [],
+        "ndcg": [],
+        "f1": [],
+        "precision": [],
+        "algorithm": [],
+        "ef_construction": [],
+        "ef_runtime": [],
+        "m": [],
+        "distance_metric": [],
+        "vector_data_type": [],
+        "objective_value": [],
+        "total_memory_mb": [],
+    }
 
 
-def update_metric_row(trial_settings: TrialSettings, trial_metrics: dict):
-    METRICS["search_method"].append(trial_settings.search_method)
-    METRICS["ret_k"].append(trial_settings.ret_k)
-    METRICS["algorithm"].append(trial_settings.index_settings.algorithm)
-    METRICS["ef_construction"].append(trial_settings.index_settings.ef_construction)
-    METRICS["ef_runtime"].append(trial_settings.index_settings.ef_runtime)
-    METRICS["m"].append(trial_settings.index_settings.m)
-    METRICS["distance_metric"].append(trial_settings.index_settings.distance_metric)
-    METRICS["vector_data_type"].append(trial_settings.index_settings.vector_data_type)
-    METRICS["model"].append(trial_settings.embedding.model)
-    METRICS["model_dim"].append(trial_settings.embedding.dim)
-    METRICS["recall"].append(trial_metrics["recall"])
-    METRICS["ndcg"].append(trial_metrics["ndcg"])
-    METRICS["precision"].append(trial_metrics["precision"])
-    METRICS["f1"].append(trial_metrics["f1"])
-    METRICS["total_indexing_time"].append(trial_metrics["total_indexing_time"])
-    METRICS["avg_query_time"].append(trial_metrics["avg_query_time"])
-    METRICS["objective_value"].append(trial_metrics["objective_value"])
-    METRICS["total_memory_mb"].append(trial_metrics["total_memory_mb"])
+def update_metric_row(
+    metrics: dict, trial_settings: TrialSettings, trial_metrics: dict
+):
+    metrics["search_method"].append(trial_settings.search_method)
+    metrics["ret_k"].append(trial_settings.ret_k)
+    metrics["algorithm"].append(trial_settings.index_settings.algorithm)
+    metrics["ef_construction"].append(trial_settings.index_settings.ef_construction)
+    metrics["ef_runtime"].append(trial_settings.index_settings.ef_runtime)
+    metrics["m"].append(trial_settings.index_settings.m)
+    metrics["distance_metric"].append(trial_settings.index_settings.distance_metric)
+    metrics["vector_data_type"].append(trial_settings.index_settings.vector_data_type)
+    metrics["model"].append(trial_settings.embedding.model)
+    metrics["model_dim"].append(trial_settings.embedding.dim)
+    metrics["recall"].append(trial_metrics["recall"])
+    metrics["ndcg"].append(trial_metrics["ndcg"])
+    metrics["precision"].append(trial_metrics["precision"])
+    metrics["f1"].append(trial_metrics["f1"])
+    metrics["total_indexing_time"].append(trial_metrics["total_indexing_time"])
+    metrics["avg_query_time"].append(trial_metrics["avg_query_time"])
+    metrics["objective_value"].append(trial_metrics["objective_value"])
+    metrics["total_memory_mb"].append(trial_metrics["total_memory_mb"])
+    return metrics
 
 
 def persist_metrics(
-    redis_url, trial_settings: TrialSettings, trial_metrics: dict, study_id
+    metrics: dict,
+    redis_url,
+    trial_settings: TrialSettings,
+    trial_metrics: dict,
+    study_id,
 ):
-    update_metric_row(trial_settings, trial_metrics)
-    logging.info(f"Saving metrics for study: {study_id}, {METRICS=}")
+    update_metric_row(metrics, trial_settings, trial_metrics)
+    logging.info(f"Saving metrics for study: {study_id}, {metrics=}")
 
     client = Redis.from_url(redis_url)
-    client.json().set(f"study:{study_id}", Path.root_path(), METRICS)
+    client.json().set(f"study:{study_id}", Path.root_path(), metrics)
 
 
 def norm_metric(value: float):
@@ -98,7 +113,9 @@ def cost_fn(metrics: dict, weights: dict):
     return objective
 
 
-def objective(trial, study_config, redis_url, corpus_processor, search_method_map):
+def objective(
+    trial, study_config, redis_url, corpus_processor, search_method_map, metrics
+):
 
     # optimizer will select hyperparameters from available option in study_config
     trial_settings = get_trial_settings(trial, study_config)
@@ -177,6 +194,7 @@ def objective(trial, study_config, redis_url, corpus_processor, search_method_ma
         index=trial_index,
         raw_queries=queries,
         emb_model=emb_model,
+        ret_k=trial_settings.ret_k,
         vector_field_name=index_settings["vector_field_name"],
         text_field_name=index_settings["text_field_name"],
     )
@@ -203,7 +221,9 @@ def objective(trial, study_config, redis_url, corpus_processor, search_method_ma
     )
 
     # save results as we go in case of failure
-    persist_metrics(redis_url, trial_settings, trial_metrics, study_config.study_id)
+    persist_metrics(
+        metrics, redis_url, trial_settings, trial_metrics, study_config.study_id
+    )
 
     return trial_metrics["objective_value"]
 
@@ -225,12 +245,16 @@ def run_bayes_study(
         pruner=optuna.pruners.MedianPruner(),
     )
 
+    # per-run accumulator so repeated calls don't inherit prior runs' rows
+    metrics = new_metrics()
+
     obj = partial(
         objective,
         study_config=study_config,
         redis_url=redis_url,
         corpus_processor=corpus_processor,
         search_method_map=search_method_map,
+        metrics=metrics,
     )
 
     study.optimize(
@@ -245,4 +269,4 @@ def run_bayes_study(
     logging.info(f"Best Configuration: {best_trial.number}: {best_trial.params}:\n\n")
     logging.info(f"Best Score: {best_trial.values}\n\n")
 
-    return pd.DataFrame(METRICS)
+    return pd.DataFrame(metrics)

--- a/redis_retrieval_optimizer/grid_study.py
+++ b/redis_retrieval_optimizer/grid_study.py
@@ -224,6 +224,7 @@ def run_grid_study(
                     index=index,
                     raw_queries=queries,
                     emb_model=emb_model,
+                    ret_k=grid_study_config.ret_k,
                     id_field_name=grid_study_config.index_settings.id_field_name,
                     vector_field_name=grid_study_config.index_settings.vector_field_name,
                     text_field_name=grid_study_config.index_settings.text_field_name,

--- a/redis_retrieval_optimizer/schema.py
+++ b/redis_retrieval_optimizer/schema.py
@@ -7,6 +7,11 @@ from redisvl.index import SearchIndex
 from redisvl.utils.vectorize.base import BaseVectorizer
 
 
+def _new_uuid() -> str:
+    """Fresh id per instance (default_factory), not a single value shared across instances."""
+    return str(uuid4())
+
+
 class QueryMetrics(BaseModel):
     """
     Tracks query execution performance metrics.
@@ -188,6 +193,10 @@ class EmbeddingModel(BaseModel):
 
 
 class MetricWeights(BaseModel):
+    # Reject unknown keys so typos (e.g. `f1_at_k`) fail loudly instead of being
+    # silently dropped and leaving every weight at 0.
+    model_config = {"extra": "forbid"}
+
     f1: float = 0
     recall: float = 0
     ndcg: float = 0
@@ -195,9 +204,27 @@ class MetricWeights(BaseModel):
     total_indexing_time: float = 0
     avg_query_time: float = 0
 
+    @model_validator(mode="after")
+    def _require_nonzero_weight(self):
+        if not any(
+            (
+                self.f1,
+                self.recall,
+                self.ndcg,
+                self.precision,
+                self.total_indexing_time,
+                self.avg_query_time,
+            )
+        ):
+            raise ValueError(
+                "at least one metric weight must be non-zero; an all-zero "
+                "objective makes the study a no-op"
+            )
+        return self
+
 
 class TrialSettings(BaseModel):
-    trial_id: str = str(uuid4())
+    trial_id: str = Field(default_factory=_new_uuid)
     index_settings: IndexSettings
     embedding: EmbeddingModel
     data: DataSettings
@@ -211,7 +238,7 @@ class OptimizationSettings(BaseModel):
     distance_metrics: list[str]
     n_trials: int
     n_jobs: int
-    metric_weights: MetricWeights = MetricWeights()
+    metric_weights: MetricWeights
     ret_k: tuple[int, int] = [1, 10]  # type: ignore # pydantic vs mypy
     ef_runtime: list = [10, 50]
     ef_construction: list = [100, 300]
@@ -219,7 +246,7 @@ class OptimizationSettings(BaseModel):
 
 
 class BayesStudyConfig(BaseModel):
-    study_id: str = str(uuid4())
+    study_id: str = Field(default_factory=_new_uuid)
     corpus: str
     qrels: str
     queries: str
@@ -230,7 +257,7 @@ class BayesStudyConfig(BaseModel):
 
 
 class GridStudyConfig(BaseModel):
-    study_id: str = str(uuid4())
+    study_id: str = Field(default_factory=_new_uuid)
     # index settings
     index_settings: IndexSettings
 
@@ -246,7 +273,7 @@ class GridStudyConfig(BaseModel):
 
 
 class SearchStudyConfig(BaseModel):
-    study_id: str = str(uuid4())
+    study_id: str = Field(default_factory=_new_uuid)
     index_name: str
 
     qrels: str
@@ -301,6 +328,13 @@ def get_trial_settings(trial, study_config):
         study_config.index_settings.ef_construction = ef_construction
         study_config.index_settings.ef_runtime = ef_runtime
         study_config.index_settings.m = m
+    else:
+        # index_settings is shared/mutated across trials; reset HNSW params to the
+        # IndexSettings defaults so a flat trial can't inherit a prior hnsw trial's
+        # ef_construction/ef_runtime/m.
+        study_config.index_settings.ef_construction = 0
+        study_config.index_settings.ef_runtime = 0
+        study_config.index_settings.m = 0
 
     embedding_settings = EmbeddingModel(
         model=model_info["model"],

--- a/tests/integration/test_ret_k.py
+++ b/tests/integration/test_ret_k.py
@@ -1,0 +1,75 @@
+"""Integration coverage for #1 — configured ret_k is actually used by the study.
+
+Before the fix the study built SearchMethodInput without ret_k, so every search
+retrieved the default 6 docs regardless of config. With a 5-doc corpus and
+queries that have 2 relevant docs each, recall at ret_k=1 is mathematically
+capped well below recall at ret_k=5 — so if ret_k is honored the two runs must
+differ. On the buggy code both runs retrieve the same 6->5 docs and recall is
+identical.
+"""
+
+import os
+
+from redisvl.index import SearchIndex
+
+import redis_retrieval_optimizer.utils as utils
+from redis_retrieval_optimizer.corpus_processors import eval_beir
+from redis_retrieval_optimizer.grid_study import run_grid_study
+
+TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+DATA = f"{TEST_DIR}/grid_data"
+
+
+def _config(ret_k: int) -> dict:
+    return {
+        "corpus": f"{DATA}/corpus.json",
+        "queries": f"{DATA}/queries.json",
+        "qrels": f"{DATA}/qrels.json",
+        "embedding_models": [
+            {
+                "dim": 384,
+                "embedding_cache_name": "vec-cache",
+                "model": "sentence-transformers/all-MiniLM-L6-v2",
+                "type": "hf",
+            }
+        ],
+        "index_settings": {
+            "from_existing": False,
+            "name": "test-retk",
+            "vector_dim": 384,
+            "additional_fields": [{"name": "title", "type": "text"}],
+        },
+        "search_methods": ["vector"],
+        "vector_data_types": ["float32"],
+        "ret_k": ret_k,
+    }
+
+
+def _cleanup(redis_url):
+    last_schema = utils.get_last_index_settings(redis_url)
+    if last_schema:
+        index = SearchIndex.from_existing(last_schema["name"], redis_url=redis_url)
+        index.client.json().delete("ret-opt:last_schema")
+        index.client.json().delete("ret-opt:last_indexing_time")
+        index.delete(drop=True)
+
+
+def test_ret_k_is_respected(redis_url):
+    try:
+        recall_k1 = run_grid_study(
+            config=_config(1),
+            redis_url=redis_url,
+            corpus_processor=eval_beir.process_corpus,
+        )["recall"].iloc[0]
+
+        recall_k5 = run_grid_study(
+            config=_config(5),
+            redis_url=redis_url,
+            corpus_processor=eval_beir.process_corpus,
+        )["recall"].iloc[0]
+
+        # ret_k=5 retrieves the whole 5-doc corpus -> every relevant doc found.
+        assert recall_k5 > recall_k1
+        assert recall_k1 < 1.0
+    finally:
+        _cleanup(redis_url)

--- a/tests/unit/test_cost_fn.py
+++ b/tests/unit/test_cost_fn.py
@@ -1,6 +1,17 @@
 import pytest
 
-from redis_retrieval_optimizer.bayes_study import cost_fn, norm_metric
+from redis_retrieval_optimizer.bayes_study import (
+    cost_fn,
+    new_metrics,
+    norm_metric,
+    update_metric_row,
+)
+from redis_retrieval_optimizer.schema import (
+    DataSettings,
+    EmbeddingModel,
+    IndexSettings,
+    TrialSettings,
+)
 
 
 class TestCostFunction:
@@ -155,3 +166,39 @@ class TestCostFunction:
         expected_total = expected_avg_query_contribution + expected_recall_contribution
 
         assert result == pytest.approx(expected_total, rel=1e-10)
+
+
+class TestMetricsIsolation:
+    """#3 — metrics accumulator is per-run, not a shared module global."""
+
+    def _trial_settings(self):
+        return TrialSettings(
+            index_settings=IndexSettings(vector_dim=384),
+            embedding=EmbeddingModel(type="hf", model="some/model", dim=384),
+            data=DataSettings(corpus="c.json", queries="q.json", qrels="r.json"),
+        )
+
+    def _trial_metrics(self):
+        return {
+            "recall": 0.5,
+            "ndcg": 0.5,
+            "precision": 0.5,
+            "f1": 0.5,
+            "total_indexing_time": 1.0,
+            "avg_query_time": 0.01,
+            "objective_value": 0.5,
+            "total_memory_mb": 10.0,
+        }
+
+    def test_new_metrics_returns_independent_dicts(self):
+        m1, m2 = new_metrics(), new_metrics()
+        m1["recall"].append(0.9)
+        assert m2["recall"] == []
+
+    def test_update_only_touches_the_passed_dict(self):
+        m1, m2 = new_metrics(), new_metrics()
+        update_metric_row(m1, self._trial_settings(), self._trial_metrics())
+
+        assert len(m1["recall"]) == 1
+        # a second run's accumulator stays empty (no leakage through a global)
+        assert len(m2["recall"]) == 0

--- a/tests/unit/test_pr1_schema_fixes.py
+++ b/tests/unit/test_pr1_schema_fixes.py
@@ -1,0 +1,160 @@
+"""Unit coverage for PR 1 correctness fixes (no Redis required).
+
+- #2 per-instance uuid defaults
+- #5 MetricWeights rejects unknown keys and all-zero weights
+- #6 get_trial_settings resets HNSW params when a non-hnsw algorithm is chosen
+"""
+
+import pytest
+from optuna.trial import FixedTrial
+from pydantic import ValidationError
+
+from redis_retrieval_optimizer.schema import (
+    BayesStudyConfig,
+    DataSettings,
+    EmbeddingModel,
+    GridStudyConfig,
+    IndexSettings,
+    MetricWeights,
+    OptimizationSettings,
+    SearchStudyConfig,
+    TrialSettings,
+    get_trial_settings,
+)
+
+
+def _embedding():
+    return EmbeddingModel(type="hf", model="some/model", dim=384)
+
+
+def _trial_settings():
+    return TrialSettings(
+        index_settings=IndexSettings(vector_dim=384),
+        embedding=_embedding(),
+        data=DataSettings(corpus="c.json", queries="q.json", qrels="r.json"),
+    )
+
+
+class TestUniqueIdDefaults:
+    """#2 — ids must be generated per instance, not once at class definition."""
+
+    def test_trial_ids_are_unique(self):
+        assert _trial_settings().trial_id != _trial_settings().trial_id
+
+    def test_bayes_study_ids_are_unique(self):
+        opt = OptimizationSettings(
+            algorithms=["flat"],
+            vector_data_types=["float32"],
+            distance_metrics=["cosine"],
+            n_trials=1,
+            n_jobs=1,
+            metric_weights=MetricWeights(f1=1),
+        )
+        kwargs = dict(
+            corpus="c.json",
+            qrels="r.json",
+            queries="q.json",
+            index_settings=IndexSettings(vector_dim=384),
+            optimization_settings=opt,
+            embedding_models=[_embedding()],
+            search_methods=["vector"],
+        )
+        assert (
+            BayesStudyConfig(**kwargs).study_id != BayesStudyConfig(**kwargs).study_id
+        )
+
+    def test_grid_and_search_study_ids_are_unique(self):
+        grid_kwargs = dict(
+            index_settings=IndexSettings(vector_dim=384),
+            qrels="r.json",
+            queries="q.json",
+            embedding_models=[_embedding()],
+            search_methods=["vector"],
+        )
+        assert (
+            GridStudyConfig(**grid_kwargs).study_id
+            != GridStudyConfig(**grid_kwargs).study_id
+        )
+
+        search_kwargs = dict(
+            index_name="idx",
+            qrels="r.json",
+            queries="q.json",
+            search_methods=["vector"],
+            embedding_model=_embedding(),
+        )
+        assert (
+            SearchStudyConfig(**search_kwargs).study_id
+            != SearchStudyConfig(**search_kwargs).study_id
+        )
+
+
+class TestMetricWeightsValidation:
+    """#5 — bad weight configs must fail loudly rather than silently no-op."""
+
+    def test_valid_weights_ok(self):
+        assert MetricWeights(f1=1).f1 == 1
+
+    def test_all_zero_weights_rejected(self):
+        with pytest.raises(ValidationError, match="non-zero"):
+            MetricWeights()
+
+    def test_unknown_weight_key_rejected(self):
+        # the exact typo that was silently dropped before (f1_at_k -> f1)
+        with pytest.raises(ValidationError):
+            MetricWeights(f1_at_k=1)
+
+
+class TestHnswParamReset:
+    """#6 — a flat trial must not inherit a prior hnsw trial's ef/m values."""
+
+    def _config(self):
+        opt = OptimizationSettings(
+            algorithms=["hnsw", "flat"],
+            vector_data_types=["float32"],
+            distance_metrics=["cosine"],
+            n_trials=2,
+            n_jobs=1,
+            metric_weights=MetricWeights(f1=1),
+        )
+        return BayesStudyConfig(
+            corpus="c.json",
+            qrels="r.json",
+            queries="q.json",
+            index_settings=IndexSettings(vector_dim=384),
+            optimization_settings=opt,
+            embedding_models=[_embedding()],
+            search_methods=["vector"],
+        )
+
+    def test_flat_trial_resets_hnsw_params(self):
+        config = self._config()
+        model_info = config.embedding_models[0].model_dump()
+        common = dict(
+            model_info=model_info,
+            search_method="vector",
+            var_dtype="float32",
+            distance_metric="cosine",
+            ret_k=5,
+        )
+
+        # hnsw trial sets ef/m on the shared index_settings
+        hnsw = get_trial_settings(
+            FixedTrial(
+                {
+                    **common,
+                    "algorithm": "hnsw",
+                    "ef_runtime": 50,
+                    "ef_construction": 300,
+                    "m": 64,
+                }
+            ),
+            config,
+        )
+        assert (hnsw.index_settings.m, hnsw.index_settings.ef_construction) == (64, 300)
+
+        # subsequent flat trial must reset them (bug left them at 64/300/50)
+        flat = get_trial_settings(FixedTrial({**common, "algorithm": "flat"}), config)
+        assert flat.index_settings.m == 0
+        assert flat.index_settings.ef_construction == 0
+        assert flat.index_settings.ef_runtime == 0

--- a/tests/unit/test_study_config_loading.py
+++ b/tests/unit/test_study_config_loading.py
@@ -140,6 +140,7 @@ class TestLoadBayesStudyConfig:
                 "n_trials": 5,
                 "ret_k": [1, 10],
                 "vector_data_types": ["float32"],
+                "metric_weights": {"f1": 1, "recall": 1},
             },
             "qrels": "/path/to/qrels.json",
             "queries": "/path/to/queries.json",


### PR DESCRIPTION
- ret_k: pass configured ret_k into SearchMethodInput in bayes and grid studies; previously both silently used the default 6, making ret_k optimization a no-op.
- study/trial ids: use Field(default_factory=...) so ids are generated per instance instead of once at import (shared id overwrote study:{id} results).
- METRICS: replace the module-level global accumulator in bayes_study with a per-run dict threaded through objective(); repeated runs no longer inherit prior rows.
- MetricWeights: forbid unknown keys (typos like f1_at_k were silently dropped) and reject all-zero weights; metric_weights is now required for bayes configs.
- get_trial_settings: reset ef_construction/ef_runtime/m on non-hnsw trials so a flat trial can't inherit a prior hnsw trial's params.

Tests (real, no mocks): unit coverage for ids, weight validation, HNSW reset (optuna FixedTrial), and metrics isolation; integration test asserting recall scales with ret_k on a real Redis index.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core optimization trial behavior and config validation (breaking for bayes configs missing metric_weights); fixes are correctness-critical but scoped to study orchestration rather than auth or data security.
> 
> **Overview**
> Fixes several **silent correctness bugs** in Bayesian and grid optimization so configured hyperparameters and objectives actually affect runs and persisted results.
> 
> **`ret_k`** is now passed into `SearchMethodInput` from trial/grid config (previously searches always used the default 6, so `ret_k` tuning was a no-op). **Study/trial IDs** use `Field(default_factory=...)` so each config instance gets its own id instead of sharing one id at import time (which could overwrite Redis `study:{id}` JSON). **Bayes metrics** move from a module-level `METRICS` dict to a per-run accumulator threaded through `objective`, so repeated `run_bayes_study` calls do not mix rows from prior runs.
> 
> **`MetricWeights`** rejects unknown keys and all-zero weights; **`metric_weights`** is required on bayes `OptimizationSettings`. **`get_trial_settings`** resets HNSW `ef_*`/`m` to defaults when a non-`hnsw` algorithm is chosen, avoiding leakage from a prior HNSW trial on shared `index_settings`.
> 
> Adds unit tests (ids, weights, HNSW reset, metrics isolation) and a Redis integration test that recall differs between `ret_k=1` and `ret_k=5`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf6c71eec851205079265282a6738bfeae622383. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->