### PR TITLE
Make search methods honor their inputs

### DIFF
--- a/redis_retrieval_optimizer/schema.py
+++ b/redis_retrieval_optimizer/schema.py
@@ -33,11 +33,14 @@ class SearchMethodInput(BaseModel):
     queries against a Redis index, including the queries, index configuration,
     and search parameters.
 
-    Query Format Options:
-    - Dictionary format: {query_id: {"query": "text", "query_metadata": {...}}}
+    Query Format Options (all normalized to {query_id: "text"} on init):
+    - Flat dict: {query_id: "text"}
+      Example: {"q1": "car search"}
+    - Nested dict: {query_id: {"query": "text", "query_metadata": {...}}}
       Example: {"q1": {"query": "car search", "query_metadata": {"make": "Toyota"}}}
-    - List format: ["query1", "query2", "query3"]
-      Example: ["car search", "truck search", "bike search"]
+      NOTE: query_metadata is not yet used for filtering; it is ignored.
+    - List: ["query1", "query2", ...]  -> keyed by positional index "0", "1", ...
+      (positional ids won't line up with qrels, so use a dict for evaluation)
     """
 
     model_config = {"arbitrary_types_allowed": True}
@@ -81,6 +84,23 @@ class SearchMethodInput(BaseModel):
         if v is not None and not isinstance(v, SearchIndex):
             raise ValueError("Must be a SearchIndex instance")
         return v
+
+    @field_validator("raw_queries")
+    @classmethod
+    def normalize_raw_queries(cls, v):
+        """Coerce the accepted input shapes into a flat {query_id: text} dict.
+
+        Search methods consume ``raw_queries[key]`` as a query string; without
+        this every method broke on the nested-dict and list forms the docstring
+        advertises. query_metadata (nested form) is dropped for now since no
+        method wires it into a filter yet.
+        """
+        if isinstance(v, list):
+            return {str(i): q for i, q in enumerate(v)}
+        normalized = {}
+        for key, val in v.items():
+            normalized[key] = val["query"] if isinstance(val, dict) else val
+        return normalized
 
 
 class SearchMethodOutput(BaseModel):

--- a/redis_retrieval_optimizer/search_methods/hybrid.py
+++ b/redis_retrieval_optimizer/search_methods/hybrid.py
@@ -11,15 +11,21 @@ logger = logging.getLogger(__name__)
 
 
 def vector_query_filter(
-    emb_model, user_query: str, num_results: int, filters=None
+    emb_model,
+    user_query: str,
+    num_results: int,
+    filters=None,
+    vector_field_name: str = "vector",
+    id_field_name: str = "_id",
+    text_field_name: str = "text",
 ) -> VectorQuery:
     """Generate a Redis vector query given user query string."""
     vector = emb_model.embed(user_query, as_buffer=True)
     query = VectorQuery(
         vector=vector,
-        vector_field_name="vector",
+        vector_field_name=vector_field_name,
         num_results=num_results,
-        return_fields=["_id", "text"],
+        return_fields=[id_field_name, text_field_name],
     )
     if filters:
         query.set_filter(filters)

--- a/redis_retrieval_optimizer/search_methods/rerank.py
+++ b/redis_retrieval_optimizer/search_methods/rerank.py
@@ -19,11 +19,19 @@ def rerank(
     num_results: int = 20,
     text_field_name: str = "text",
     id_field_name: str = "_id",
+    vector_field_name: str = "vector",
 ) -> List[Dict[str, Any]]:
     """Rerank the candidates based on the user query with an external model/module."""
 
     # Create the vector query default larger set that is pruned down to ret_k
-    vector_query = vector_query_filter(emb_model, user_query, num_results=20)
+    vector_query = vector_query_filter(
+        emb_model,
+        user_query,
+        num_results=20,
+        vector_field_name=vector_field_name,
+        id_field_name=id_field_name,
+        text_field_name=text_field_name,
+    )
 
     # Create the full-text query default larger set that is pruned down to ret_k
     full_text_query = bm25_query_optional(
@@ -83,6 +91,7 @@ def gather_rerank_results(search_method_input: SearchMethodInput):
                 num_results=search_method_input.ret_k,
                 text_field_name=search_method_input.text_field_name,
                 id_field_name=search_method_input.id_field_name,
+                vector_field_name=search_method_input.vector_field_name,
             )
             scores_dict = make_score_dict_rerank(rerank_res)
         except Exception as e:

--- a/redis_retrieval_optimizer/search_methods/vector.py
+++ b/redis_retrieval_optimizer/search_methods/vector.py
@@ -36,7 +36,8 @@ def make_score_dict_vec(res, id_field_name: str) -> dict:
         return {"no_match": 0}
     for rec in res:
         if id_field_name in rec:
-            scores_dict[rec[id_field_name]] = 2 - float(rec["vector_distance"]) / 2
+            # cosine distance in [0, 2] -> similarity in [0, 1]
+            scores_dict[rec[id_field_name]] = (2 - float(rec["vector_distance"])) / 2
         else:
             scores_dict["no_match"] = 0
 

--- a/redis_retrieval_optimizer/search_methods/weighted_rrf.py
+++ b/redis_retrieval_optimizer/search_methods/weighted_rrf.py
@@ -43,15 +43,24 @@ def weighted_rrf(
     num_results: int = 4,
     k: int = 20,
     id_field_name: str = "_id",
+    text_field_name: str = "text",
+    vector_field_name: str = "vector",
 ) -> List[Dict[str, Any]]:
     """Implemented client-side RRF after querying from Redis."""
 
     # Create the vector query
-    vector_query = vector_query_filter(emb_model, user_query, num_results=k)
+    vector_query = vector_query_filter(
+        emb_model,
+        user_query,
+        num_results=k,
+        vector_field_name=vector_field_name,
+        id_field_name=id_field_name,
+        text_field_name=text_field_name,
+    )
 
     # Create the full-text bm25 query
     full_text_query = bm25_query_optional(
-        "text", id_field_name, user_query, num_results=k
+        text_field_name, id_field_name, user_query, num_results=k
     )
 
     # Run queries individually
@@ -86,6 +95,8 @@ def gather_weighted_rrf(search_method_input: SearchMethodInput) -> SearchMethodO
                 num_results=search_method_input.ret_k,
                 k=20,  # TODO make this configurable
                 id_field_name=search_method_input.id_field_name,
+                text_field_name=search_method_input.text_field_name,
+                vector_field_name=search_method_input.vector_field_name,
             )
             scores_dict = make_score_dict_w_rff(w_rff)
         except Exception as e:

--- a/tests/integration/test_search_methods.py
+++ b/tests/integration/test_search_methods.py
@@ -182,9 +182,9 @@ def test_make_score_dict_vec():
     # Verify scores are calculated correctly
     assert "doc1" in scores
     assert "doc2" in scores
-    # Score should be 2 - distance/2
-    assert scores["doc1"] == 2 - 0.2 / 2
-    assert scores["doc2"] == 2 - 0.5 / 2
+    # cosine distance in [0, 2] -> similarity in [0, 1]
+    assert scores["doc1"] == (2 - 0.2) / 2
+    assert scores["doc2"] == (2 - 0.5) / 2
 
     # Test with empty results
     empty_scores = make_score_dict_vec([], "_id")
@@ -380,6 +380,103 @@ def test_gather_hybrid_8_4_results(vector_index, test_data):
     f1 = evaluate(qrels, result.run, metrics=["f1"])
 
     assert f1 > 0
+
+
+@pytest.fixture
+def custom_field_index(redis_url, test_data):
+    """Index using non-default field names (doc_id/body/embedding)."""
+    corpus, _, _ = test_data
+    emb_model = HFTextVectorizer(model="sentence-transformers/all-MiniLM-L6-v2")
+
+    schema = {
+        "index": {"name": "test-custom", "prefix": "test-custom"},
+        "fields": [
+            {"name": "doc_id", "type": "tag"},
+            {"name": "body", "type": "text"},
+            {
+                "name": "embedding",
+                "type": "vector",
+                "attrs": {
+                    "dims": 384,
+                    "distance_metric": "cosine",
+                    "algorithm": "flat",
+                    "datatype": "float32",
+                },
+            },
+        ],
+    }
+
+    index = SearchIndex.from_dict(schema, redis_url=redis_url)
+    try:
+        index.delete(drop=True)
+    except Exception:
+        pass
+    index.create()
+
+    docs = [
+        {
+            "doc_id": doc_id,
+            "body": doc["text"],
+            "embedding": emb_model.embed(doc["text"], as_buffer=True),
+        }
+        for doc_id, doc in corpus.items()
+    ]
+    index.load(docs)
+
+    yield index, emb_model
+
+    index.delete(drop=True)
+
+
+def test_weighted_rrf_honors_custom_field_names(custom_field_index, test_data):
+    """#4 — weighted_rrf must query the configured fields, not hardcoded ones.
+
+    On the pre-fix code the vector/bm25 queries hit "vector"/"text"/"_id",
+    which don't exist here, so every query errors out to {"no_match": 0} and
+    f1 is 0.
+    """
+    from redis_retrieval_optimizer.search_methods.weighted_rrf import (
+        gather_weighted_rrf,
+    )
+
+    index, emb_model = custom_field_index
+    _, queries, qrels = test_data
+
+    search_input = SearchMethodInput(
+        index=index,
+        raw_queries=queries,
+        emb_model=emb_model,
+        id_field_name="doc_id",
+        text_field_name="body",
+        vector_field_name="embedding",
+    )
+
+    result = gather_weighted_rrf(search_input)
+
+    assert isinstance(result.run, Run)
+    assert evaluate(qrels, result.run, metrics=["f1"]) > 0
+
+
+def test_rerank_honors_custom_field_names(custom_field_index, test_data):
+    """#4 — rerank's vector candidate query must use the configured fields."""
+    from redis_retrieval_optimizer.search_methods.rerank import gather_rerank_results
+
+    index, emb_model = custom_field_index
+    _, queries, qrels = test_data
+
+    search_input = SearchMethodInput(
+        index=index,
+        raw_queries=queries,
+        emb_model=emb_model,
+        id_field_name="doc_id",
+        text_field_name="body",
+        vector_field_name="embedding",
+    )
+
+    result = gather_rerank_results(search_input)
+
+    assert isinstance(result.run, Run)
+    assert evaluate(qrels, result.run, metrics=["f1"]) > 0
 
 
 def test_gather_rrf_8_4_results(vector_index, test_data):

--- a/tests/unit/test_search_method_inputs.py
+++ b/tests/unit/test_search_method_inputs.py
@@ -1,0 +1,49 @@
+"""Unit coverage for PR 2 search-method input handling (no Redis required).
+
+- #13 SearchMethodInput normalizes the documented query shapes to {id: text}
+- #14 vector similarity score maps cosine distance [0, 2] -> [0, 1]
+"""
+
+from redis_retrieval_optimizer.schema import SearchMethodInput
+from redis_retrieval_optimizer.search_methods.vector import make_score_dict_vec
+
+
+class TestRawQueryNormalization:
+    """#13 — every documented query shape becomes {query_id: text}."""
+
+    def test_flat_dict_unchanged(self):
+        si = SearchMethodInput(raw_queries={"q1": "hello"}, index=None)
+        assert si.raw_queries == {"q1": "hello"}
+
+    def test_nested_dict_extracts_query_and_drops_metadata(self):
+        si = SearchMethodInput(
+            raw_queries={"q1": {"query": "hello", "query_metadata": {"make": "x"}}},
+            index=None,
+        )
+        assert si.raw_queries == {"q1": "hello"}
+
+    def test_list_is_keyed_by_position(self):
+        si = SearchMethodInput(raw_queries=["a", "b", "c"], index=None)
+        assert si.raw_queries == {"0": "a", "1": "b", "2": "c"}
+
+
+class TestVectorScoreBounds:
+    """#14 — cosine distance is mapped to a [0, 1] similarity."""
+
+    def test_perfect_match_scores_one(self):
+        assert make_score_dict_vec([{"_id": "d", "vector_distance": 0.0}], "_id") == {
+            "d": 1.0
+        }
+
+    def test_orthogonal_scores_half(self):
+        assert make_score_dict_vec([{"_id": "d", "vector_distance": 1.0}], "_id") == {
+            "d": 0.5
+        }
+
+    def test_opposite_scores_zero(self):
+        assert make_score_dict_vec([{"_id": "d", "vector_distance": 2.0}], "_id") == {
+            "d": 0.0
+        }
+
+    def test_empty_results(self):
+        assert make_score_dict_vec([], "_id") == {"no_match": 0}


### PR DESCRIPTION
- field names: vector_query_filter now accepts vector/id/text field names; weighted_rrf and rerank thread the configured names through instead of querying hardcoded "vector"/"text"/"_id" fields. Non-default field names previously made these two methods silently return no matches.
- query formats: a field_validator on SearchMethodInput.raw_queries normalizes the three documented shapes (flat dict, nested {"query": ...} dict, list) to {id: text}; before, nested-dict and list inputs crashed every method. query_metadata is dropped (no filtering wired yet) and the docstring says so.
- vector score: map cosine distance [0,2] to similarity [0,1] as (2-d)/2 instead of 2-d/2 (was [1,2]); ranking is unaffected but the persisted score is now meaningful.

Tests (real, no mocks): unit coverage for query normalization and score bounds; integration tests running weighted_rrf and rerank against an index with non-default field names (asserts f1>0, impossible on the pre-fix code).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core retrieval input handling and persisted vector scores; behavior fixes are low-risk for default indexes but change outcomes for custom field names and nested/list query inputs.
> 
> **Overview**
> Search methods now respect **`SearchMethodInput`** instead of assuming fixed query shapes and Redis field names.
> 
> **Query inputs:** A `raw_queries` validator normalizes flat dicts, nested `{"query": ...}` dicts (metadata dropped), and lists (positional `"0"`, `"1"`, … keys) to `{query_id: text}` so callers no longer crash when using the documented non-flat formats.
> 
> **Index fields:** `vector_query_filter` takes configurable vector/id/text field names; **weighted RRF** and **rerank** pass `SearchMethodInput` field settings through instead of hardcoded `"vector"` / `"text"` / `"_id"`, which previously yielded silent no-match results on custom schemas.
> 
> **Vector scores:** Cosine distance is mapped to similarity with `(2 - d) / 2` so scores sit in **[0, 1]** (ranking unchanged).
> 
> Unit tests cover normalization and score bounds; integration tests run weighted RRF and rerank against an index with non-default field names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9834fa925bb0aae41418bb213d2ca34817b2cbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->