### PR TITLE
Fix Redis helpers & memory accounting

### DIFF
--- a/redis_retrieval_optimizer/memory_usage/utils.py
+++ b/redis_retrieval_optimizer/memory_usage/utils.py
@@ -65,7 +65,8 @@ def estimate_index_size(
         else False
     )
     sample_vec = emb_model.embed("test embedding", as_buffer=as_buffer)
-    sample_object[vector_field_name] = sample_vec
+    # copy so we don't mutate the caller's dict by adding the vector field
+    sample_object = {**sample_object, vector_field_name: sample_vec}
 
     sample_objects = [sample_object] * num_objects
 
@@ -88,8 +89,7 @@ def estimate_index_size(
 
     logger.info("Calculating memory usage per key")
     for key in keys:
-        key_memory = index.client.memory_usage(key)
-        memory_usage_keys_bytes += key_memory
+        memory_usage_keys_bytes += index.client.memory_usage(key)
 
     info = index.info()
 
@@ -103,6 +103,9 @@ def estimate_index_size(
     )  # total memory used by all indexes
     object_memory_mb = memory_usage_keys_bytes / (1024**2)
     total_memory_mb = index_memory_mb + (object_memory_mb)
+
+    # average per-key memory; guard against an empty load (num_objects == 0)
+    single_key_memory_mb = object_memory_mb / len(keys) if keys else 0.0
 
     index_memory_gb = index_memory_mb / 1024
     object_memory_gb = object_memory_mb / 1024
@@ -127,5 +130,5 @@ def estimate_index_size(
         "object_memory_gb": object_memory_gb,
         "total_memory_gb": total_memory_gb,
         "info_used_memory_gb": info_used_memory_gb,
-        "single_key_memory_mb": key_memory / (1024**2),
+        "single_key_memory_mb": single_key_memory_mb,
     }

--- a/redis_retrieval_optimizer/utils.py
+++ b/redis_retrieval_optimizer/utils.py
@@ -60,14 +60,22 @@ def vectorizer_from_dict(
         raise ValueError(f"Unsupported vectorizer type: {vectorizer_type}")
 
 
+# Internal bookkeeping keys. These live under the default "ret-opt" prefix, so
+# they must be excluded from per-object memory accounting (see
+# get_index_memory_stats) to avoid counting them as indexed documents.
+LAST_SCHEMA_KEY = "ret-opt:last_schema"
+LAST_INDEXING_TIME_KEY = "ret-opt:last_indexing_time"
+BOOKKEEPING_KEYS = {LAST_SCHEMA_KEY, LAST_INDEXING_TIME_KEY}
+
+
 def get_last_index_settings(redis_url):
     client = Redis.from_url(redis_url)
-    return client.json().get("ret-opt:last_schema")
+    return client.json().get(LAST_SCHEMA_KEY)
 
 
 def set_last_index_settings(redis_url, index_settings):
     client = Redis.from_url(redis_url)
-    client.json().set("ret-opt:last_schema", Path.root_path(), index_settings)
+    client.json().set(LAST_SCHEMA_KEY, Path.root_path(), index_settings)
 
 
 def get_last_indexing_time(redis_url: str) -> float | None:
@@ -77,7 +85,7 @@ def get_last_indexing_time(redis_url: str) -> float | None:
     indexing time across runs where we do not reload data.
     """
     client = Redis.from_url(redis_url)
-    value = client.json().get("ret-opt:last_indexing_time")
+    value = client.json().get(LAST_INDEXING_TIME_KEY)
     return float(value) if value is not None else None
 
 
@@ -88,30 +96,35 @@ def set_last_indexing_time(redis_url: str, indexing_time: float) -> None:
     and therefore should reuse the previously measured indexing time.
     """
     client = Redis.from_url(redis_url)
-    client.json().set("ret-opt:last_indexing_time", Path.root_path(), indexing_time)
+    client.json().set(LAST_INDEXING_TIME_KEY, Path.root_path(), indexing_time)
 
 
 def check_recreate(index_settings, last_index_settings):
-    embedding_settings = index_settings.pop("embedding") if index_settings else None
+    # Compare everything except "embedding" (handled separately below) without
+    # mutating the caller's dicts -- this used to .pop("embedding") off both
+    # inputs, forcing callers to re-insert the key afterward.
+    def _without_embedding(settings):
+        return (
+            {k: v for k, v in settings.items() if k != "embedding"} if settings else {}
+        )
+
+    embedding_settings = index_settings.get("embedding") if index_settings else None
     last_embedding_settings = (
-        last_index_settings.pop("embedding") if last_index_settings else None
+        last_index_settings.get("embedding") if last_index_settings else None
     )
+
+    current = _without_embedding(index_settings)
+    last = _without_embedding(last_index_settings)
 
     if not last_index_settings:
         recreate_index = True
         recreate_data = True
-    elif index_settings != last_index_settings:
+    elif current != last:
         recreate_index = True
 
         # Check if vector_data_type changed - this requires data recreation
         # because vectors must be re-embedded with the new dtype
-        current_dtype = (
-            index_settings.get("vector_data_type") if index_settings else None
-        )
-        last_dtype = (
-            last_index_settings.get("vector_data_type") if last_index_settings else None
-        )
-        dtype_changed = current_dtype != last_dtype
+        dtype_changed = current.get("vector_data_type") != last.get("vector_data_type")
 
         if embedding_settings != last_embedding_settings or dtype_changed:
             recreate_data = True
@@ -268,11 +281,17 @@ def get_index_memory_stats(index_name: str, prefix: str, redis_url: str):
     index_info = index.info()
     total_index_memory_sz_mb = index_info["total_index_memory_sz_mb"]
 
-    index_keys = index.client.keys(f"{prefix}*")
-
     memory_data_bytes = 0
-    for key in index_keys:
-        memory_data_bytes += index.client.memory_usage(key)
+    # SCAN instead of the blocking KEYS, and skip internal bookkeeping keys
+    # (ret-opt:last_schema / ret-opt:last_indexing_time), which share the default
+    # "ret-opt" prefix and would otherwise be counted as indexed objects.
+    for key in index.client.scan_iter(match=f"{prefix}*", count=1000):
+        key_str = key.decode() if isinstance(key, bytes) else key
+        if key_str in BOOKKEEPING_KEYS:
+            continue
+        usage = index.client.memory_usage(key)
+        if usage:
+            memory_data_bytes += usage
 
     return {
         "total_index_memory_sz_mb": float(total_index_memory_sz_mb),

--- a/tests/integration/test_memory_stats.py
+++ b/tests/integration/test_memory_stats.py
@@ -1,0 +1,65 @@
+"""Integration coverage for #12 — get_index_memory_stats must not count the
+internal bookkeeping keys (ret-opt:last_schema / ret-opt:last_indexing_time)
+as indexed objects. They share the default "ret-opt" prefix, so the old
+KEYS("ret-opt*") scan swept them in.
+"""
+
+import numpy as np
+from redisvl.index import SearchIndex
+
+import redis_retrieval_optimizer.utils as utils
+from redis_retrieval_optimizer.utils import get_index_memory_stats
+
+PREFIX = "ret-opt"
+
+
+def test_bookkeeping_keys_excluded_from_object_memory(redis_url):
+    schema = {
+        "index": {"name": PREFIX, "prefix": PREFIX},
+        "fields": [
+            {"name": "_id", "type": "tag"},
+            {"name": "text", "type": "text"},
+            {
+                "name": "vector",
+                "type": "vector",
+                "attrs": {
+                    "dims": 3,
+                    "distance_metric": "cosine",
+                    "algorithm": "flat",
+                    "datatype": "float32",
+                },
+            },
+        ],
+    }
+
+    index = SearchIndex.from_dict(schema, redis_url=redis_url)
+    try:
+        index.delete(drop=True)
+    except Exception:
+        pass
+    index.create()
+
+    vec = np.array([0.1, 0.2, 0.3], dtype=np.float32).tobytes()
+    index.load([{"_id": f"d{i}", "text": "t", "vector": vec} for i in range(3)])
+
+    client = index.client
+    try:
+        # measure with no bookkeeping keys present
+        client.delete(utils.LAST_SCHEMA_KEY, utils.LAST_INDEXING_TIME_KEY)
+        absent = get_index_memory_stats(PREFIX, PREFIX, redis_url)[
+            "total_object_memory_mb"
+        ]
+
+        # add the bookkeeping keys under the same prefix
+        utils.set_last_index_settings(redis_url, {"name": PREFIX})
+        utils.set_last_indexing_time(redis_url, 1.23)
+        present = get_index_memory_stats(PREFIX, PREFIX, redis_url)[
+            "total_object_memory_mb"
+        ]
+
+        assert absent > 0  # the 3 real docs are counted
+        # excluding bookkeeping keys means the count is unchanged by their presence
+        assert present == absent
+    finally:
+        client.delete(utils.LAST_SCHEMA_KEY, utils.LAST_INDEXING_TIME_KEY)
+        index.delete(drop=True)

--- a/tests/unit/test_check_recreate.py
+++ b/tests/unit/test_check_recreate.py
@@ -1,0 +1,46 @@
+"""Unit coverage for #11 — check_recreate must not mutate its inputs (no Redis)."""
+
+from redis_retrieval_optimizer.utils import check_recreate
+
+
+def _settings():
+    return {
+        "name": "idx",
+        "vector_data_type": "float32",
+        "embedding": {"model": "m", "dim": 384},
+    }
+
+
+def test_no_last_settings_recreates_everything():
+    assert check_recreate(_settings(), None) == (True, True)
+
+
+def test_identical_settings_recreate_nothing():
+    assert check_recreate(_settings(), _settings()) == (False, False)
+
+
+def test_does_not_mutate_inputs():
+    current, last = _settings(), _settings()
+    check_recreate(current, last)
+    # the old implementation .pop()'d "embedding" off both dicts
+    assert "embedding" in current
+    assert "embedding" in last
+
+
+def test_index_field_change_recreates_index_but_keeps_data():
+    current = _settings()
+    current["name"] = "other"
+    assert check_recreate(current, _settings()) == (True, False)
+
+
+def test_dtype_change_recreates_data():
+    current = _settings()
+    current["vector_data_type"] = "float16"
+    assert check_recreate(current, _settings()) == (True, True)
+
+
+def test_embedding_change_alongside_index_change_recreates_data():
+    current = _settings()
+    current["name"] = "other"
+    current["embedding"] = {"model": "different", "dim": 384}
+    assert check_recreate(current, _settings()) == (True, True)

--- a/tests/unit/test_memory_usage_utils.py
+++ b/tests/unit/test_memory_usage_utils.py
@@ -132,3 +132,43 @@ def test_estimate_index_size_computes_expected_memory_stats(monkeypatch):
 
     # Single key memory should be 1 MiB
     assert result["single_key_memory_mb"] == pytest.approx(1.0)
+
+
+def test_estimate_index_size_does_not_mutate_caller_object(monkeypatch):
+    """#7 — the vector field must not leak back into the caller's dict."""
+    monkeypatch.setattr(
+        mem_utils, "vectorizer_from_dict", lambda info: DummyVectorizer()
+    )
+    monkeypatch.setattr(mem_utils, "SearchIndex", FakeSearchIndex)
+
+    sample_object = {"id": "1"}
+    mem_utils.estimate_index_size(
+        sample_object=sample_object,
+        num_objects=2,
+        schema=DummySchema(),
+        embedding_model_info={"model": "dummy"},
+        redis_url="redis://localhost:6379",
+        vector_field_name="vector",
+    )
+
+    assert sample_object == {"id": "1"}  # no "vector" key added
+
+
+def test_estimate_index_size_handles_zero_objects(monkeypatch):
+    """#7 — empty load must not raise NameError on single_key_memory_mb."""
+    monkeypatch.setattr(
+        mem_utils, "vectorizer_from_dict", lambda info: DummyVectorizer()
+    )
+    monkeypatch.setattr(mem_utils, "SearchIndex", FakeSearchIndex)
+
+    result = mem_utils.estimate_index_size(
+        sample_object={"id": "1"},
+        num_objects=0,
+        schema=DummySchema(),
+        embedding_model_info={"model": "dummy"},
+        redis_url="redis://localhost:6379",
+        vector_field_name="vector",
+    )
+
+    assert result["single_key_memory_mb"] == 0.0
+    assert result["object_memory_mb"] == 0.0


### PR DESCRIPTION
- check_recreate no longer mutates its inputs. It used to .pop("embedding") off both dicts, forcing callers to re-insert the key; now it compares copies without embedding. Recreate decisions are unchanged.
- get_index_memory_stats uses SCAN instead of the blocking KEYS, and skips the internal bookkeeping keys (ret-opt:last_schema / ret-opt:last_indexing_time) which share the default "ret-opt" prefix and were being counted as indexed object memory. Added module constants for those key names.
- estimate_index_size no longer mutates the caller's sample_object (copies before adding the vector field) and computes single_key_memory_mb as an average guarded against an empty load (was a NameError on the leftover loop variable when num_objects == 0).

Tests: unit coverage for check_recreate (non-mutation + recreate decisions), estimate_index_size (no caller mutation, zero-object guard); integration test proving bookkeeping keys are excluded from object-memory accounting on real Redis.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect index recreate decisions’ inputs and reported memory metrics used for sizing; behavior is intended to be equivalent except for corrected accounting and non-mutation, with new test coverage.
> 
> **Overview**
> Fixes **Redis helper side effects** and **memory statistics** so optimization runs get accurate sizing and stable settings dicts.
> 
> **`check_recreate`** compares index settings without removing `"embedding"` from the caller’s dicts (previously `.pop` forced re-insertion). Recreate index/data decisions are unchanged.
> 
> **`get_index_memory_stats`** replaces blocking `KEYS` with **`SCAN`**, and skips internal keys `ret-opt:last_schema` / `ret-opt:last_indexing_time` (new module constants) so they are not counted as indexed object memory under the default `ret-opt` prefix.
> 
> **`estimate_index_size`** copies the sample object before attaching the vector field, and computes **`single_key_memory_mb`** as a safe average (0 when no keys load), fixing a `NameError` on zero-object runs.
> 
> Adds unit tests for `check_recreate` and `estimate_index_size`, plus an integration test that bookkeeping keys do not inflate `total_object_memory_mb`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64bc10f042f2d08d9b203df9769aa5bf681e4ac4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->