### PR TITLE
Fix small isolated bugs

### DIFF
--- a/redis_retrieval_optimizer/__init__.py
+++ b/redis_retrieval_optimizer/__init__.py
@@ -1,3 +1,3 @@
 __version__ = "0.5.1"
 
-all = ["__version__"]
+__all__ = ["__version__"]

--- a/redis_retrieval_optimizer/corpus_processors/eval_beir.py
+++ b/redis_retrieval_optimizer/corpus_processors/eval_beir.py
@@ -15,15 +15,15 @@ def get_beir_dataset(dataset="fiqa"):
     return corpus, queries, qrels
 
 
-def process_corpus(corpus: any, emb_model: BaseVectorizer):
+def process_corpus(corpus: dict, emb_model: BaseVectorizer):
     corpus_data = []
     corpus_texts = []
 
     # this can take a minute
     for key in corpus:
-        corpus_texts.append(
-            corpus[key]["title"] + " " + corpus[key]["text"]
-        )  # note: embedded both text and title
+        # title is optional in BEIR-style corpora; embed title + text
+        title = corpus[key].get("title", "")
+        corpus_texts.append(f"{title} {corpus[key]['text']}".strip())
 
     text_embeddings = emb_model.embed_many(corpus_texts, as_buffer=True)
 
@@ -32,7 +32,7 @@ def process_corpus(corpus: any, emb_model: BaseVectorizer):
             {
                 "_id": key,
                 "text": text,
-                "title": corpus[key]["title"],
+                "title": corpus[key].get("title", ""),
                 "vector": embedding,
             }
         )

--- a/redis_retrieval_optimizer/grid_study.py
+++ b/redis_retrieval_optimizer/grid_study.py
@@ -81,14 +81,12 @@ def init_index_from_grid_settings(
         logger.info(
             f"From existing, assuming {grid_study_config.embedding_models[0].model} embedding model"
         )
-        if (
-            embed_settings.dim
-            != index.schema.fields[
-                grid_study_config.index_settings.vector_field_name
-            ].attrs.dims
-        ):
+        index_dim = index.schema.fields[
+            grid_study_config.index_settings.vector_field_name
+        ].attrs.dims
+        if embed_settings.dim != index_dim:
             raise ValueError(
-                f"Embedding model dimension {embed_settings.dim} does not match index dimension {index.schema.fields[grid_study_config.index_settings.vector_field_name].attrs['dims']}"
+                f"Embedding model dimension {embed_settings.dim} does not match index dimension {index_dim}"
             )
         utils.set_last_index_settings(redis_url, index_settings)
     else:

--- a/tests/integration/test_grid_from_existing.py
+++ b/tests/integration/test_grid_from_existing.py
@@ -1,0 +1,63 @@
+"""Integration coverage for #9 — the from_existing dim-mismatch error path.
+
+Pre-fix the error message interpolated `.attrs['dims']` (subscript) on a
+pydantic attrs model, which raised TypeError while *building* the message, so
+the caller saw a TypeError instead of the intended ValueError.
+"""
+
+import pytest
+from redisvl.index import SearchIndex
+
+from redis_retrieval_optimizer.grid_study import init_index_from_grid_settings
+from redis_retrieval_optimizer.utils import load_grid_study_config
+
+IDX = "test-dim-mismatch"
+
+
+def test_from_existing_dim_mismatch_raises_valueerror(redis_url):
+    schema = {
+        "index": {"name": IDX, "prefix": IDX},
+        "fields": [
+            {"name": "_id", "type": "tag"},
+            {"name": "text", "type": "text"},
+            {
+                "name": "vector",
+                "type": "vector",
+                "attrs": {
+                    "dims": 384,
+                    "distance_metric": "cosine",
+                    "algorithm": "flat",
+                    "datatype": "float32",
+                },
+            },
+        ],
+    }
+    index = SearchIndex.from_dict(schema, redis_url=redis_url)
+    try:
+        index.delete(drop=True)
+    except Exception:
+        pass
+    index.create()
+
+    try:
+        # config declares a 128-dim embedding against the existing 384-dim index
+        config = load_grid_study_config(
+            config={
+                "index_settings": {
+                    "name": IDX,
+                    "from_existing": True,
+                    "vector_dim": 128,
+                },
+                "embedding_models": [{"type": "hf", "model": "m", "dim": 128}],
+                "search_methods": ["vector"],
+                "qrels": "unused.json",
+                "queries": "unused.json",
+            }
+        )
+
+        with pytest.raises(ValueError, match="does not match index dimension"):
+            init_index_from_grid_settings(
+                config, redis_url, corpus_processor=lambda *a, **k: []
+            )
+    finally:
+        index.delete(drop=True)

--- a/tests/unit/test_small_fixes.py
+++ b/tests/unit/test_small_fixes.py
@@ -1,0 +1,46 @@
+"""Unit coverage for PR 4 small isolated fixes (no Redis required).
+
+- #8  package exports __all__ (was the shadowed builtin `all`)
+- #10 process_corpus tolerates title-less corpora and uses a real type hint
+"""
+
+import redis_retrieval_optimizer
+from redis_retrieval_optimizer.corpus_processors import eval_beir
+
+
+class _StubEmbedder:
+    """Minimal stand-in so we exercise process_corpus's real text-building logic
+    without downloading an embedding model (the logic under test is the title
+    handling, not the embedding)."""
+
+    def embed_many(self, texts, as_buffer=False):
+        self.seen = list(texts)
+        return [b"vec" for _ in texts]
+
+
+def test_package_exports_all():
+    # #8 — must be the dunder, not the shadowed builtin `all`
+    assert redis_retrieval_optimizer.__all__ == ["__version__"]
+
+
+def test_process_corpus_handles_missing_title():
+    # #10 — no "title" key should not raise KeyError
+    corpus = {"d1": {"text": "hello world"}}
+
+    result = eval_beir.process_corpus(corpus, _StubEmbedder())
+
+    assert len(result) == 1
+    assert result[0]["_id"] == "d1"
+    assert result[0]["title"] == ""
+    assert result[0]["text"] == "hello world"  # leading space stripped
+
+
+def test_process_corpus_with_title_embeds_title_and_text():
+    corpus = {"d1": {"title": "Cats", "text": "are great"}}
+    embedder = _StubEmbedder()
+
+    result = eval_beir.process_corpus(corpus, embedder)
+
+    assert embedder.seen == ["Cats are great"]
+    assert result[0]["title"] == "Cats"
+    assert result[0]["text"] == "Cats are great"


### PR DESCRIPTION
- __init__.py: export __all__ (was `all`, which shadowed the builtin and exported nothing).
- grid_study.py: the from_existing dim-mismatch error interpolated `.attrs['dims']` (subscript) while the comparison used `.attrs.dims` (attribute); building the message raised TypeError instead of the intended ValueError. Compute the index dim once and reuse it.
- eval_beir.process_corpus: annotate `corpus: dict` (was the builtin `any`) and tolerate title-less corpora via `.get("title", "")` instead of a KeyError-prone subscript.

Tests: unit coverage for __all__ and title-less/with-title corpus processing; integration test asserting the from_existing dim mismatch raises ValueError.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized bug fixes in export metadata, corpus preprocessing, and error messaging; behavior changes only fix incorrect failures and improve diagnostics.
> 
> **Overview**
> Fixes three small bugs and adds tests for each.
> 
> **Package exports:** Replaces mistaken `all = [...]` with `__all__` so `__version__` is actually exported instead of shadowing the builtin.
> 
> **BEIR `process_corpus`:** Types `corpus` as `dict` (not `any`) and treats `title` as optional via `.get("title", "")`, building embed text with `strip()` so title-less documents no longer raise `KeyError`.
> 
> **Grid study `from_existing`:** Reads index vector dimension once as `index_dim` and uses it in both the comparison and `ValueError` message, fixing a bug where subscripting `.attrs['dims']` on the Pydantic attrs model raised `TypeError` instead of the intended mismatch error.
> 
> **Tests:** Unit tests for `__all__` and title-less/with-title corpus handling; integration test that dim mismatch raises `ValueError` with the expected message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e9446414ca1501928a52187cdbe94d663e2e74e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->